### PR TITLE
feat: mail client send 'fetch' or 'main' FE route

### DIFF
--- a/src/checkVaild.ts
+++ b/src/checkVaild.ts
@@ -2,6 +2,7 @@ import request from 'request'
 import { domain } from './varables'
 import { isUserExist, createUser } from './models'
 import { signToken } from './jwt'
+import { searchUser } from './models'
 
 type TypeRes = {
   result: boolean
@@ -28,14 +29,19 @@ const isNotVaild = (mailid: string) =>
     )
   })
 
-export type LoginResult = { token: string } | { error: number }
+export type LoginResult = { token: string; isNull: boolean } | { error: number }
 
 export const login = async (mailid: string): Promise<LoginResult> => {
   const mailAddress = `${mailid}@${domain}`
   if (await isNotVaild(mailAddress)) return { error: 401 }
   try {
-    if (!(await isUserExist(mailid))) await createUser({ mailid })
-    return { token: signToken(mailid) }
+    if (!(await isUserExist(mailid))) {
+      await createUser({ mailid })
+    }
+    return {
+      token: signToken(mailid),
+      isNull: !(await searchUser(mailid)).name,
+    }
   } catch (e) {
     return { error: 501 }
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -34,9 +34,11 @@ export const loginRoute = async (
     return
   }
 
+  const route = result.isNull ? 'fetch' : 'main'
+
   await sendMail({
     to: `${mailid}@${domain}`,
-    text: `localhost:3000/main&token=${result.token}`,
+    text: `localhost:3000/${route}?token=${result.token}`,
   })
 
   res.status(201).end()


### PR DESCRIPTION
> Front end need new route call '/fetch'.
> Because view is difficult to control with ‘/main’ route.

백단의 `/login` 라우터가 던져주는 URL 값을 두가지로 나누는 작업을 하게 되었습니다

## 문제

```ts
  FAIL  src/index.test.ts
  POST /login is
    body as '{"mailid":"muhunkim"}' send
      ✓ return 401 status code (124ms)
    body as '{"mailid":"muhun"}' send
      ✕ return 201 status code (27ms)
  POST /fetch is
    send vaild token
      ✓ return 401 status code with invaild form (150ms)
      ✓ return 201 status code with vaild form (55ms)
    send invaild token
      ✓ return 401 status code (15ms)
  GET /load
    send vaild token
      ✓ return 200 status code (3ms)
    send invaild token
      ✓ return 401 status code (4ms)

  ● POST /login is › body as '{"mailid":"muhun"}' send › return 201 status code

    expected 201 "Created", got 501 "Not Implemented"
```

`login` 라우트에서 501을 반환을 하고 있습니다.
```ts
[nodemon] app crashed - waiting for file changes before starting...
[nodemon] restarting due to changes...
[nodemon] starting `ts-node bin/www.ts`
server start
Error: Cannot find the muhun
    at /Users/muhun/github/reflation/backend/src/models/__mocks__/index.ts:24:
```

E2E 환경에서도 그래서 오류를 찍어보니 전혀 쓰이질 않는 mock 쪽에서 id를 찾고 있네요??